### PR TITLE
Remove unused autoload-dev block from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,6 @@
             "Reworck\\FilamentSettings\\": "src"
         }
     },
-    "autoload-dev": {
-        "psr-4": {
-            "ShuvroRoy\\FilamentSettings\\Tests\\": "tests"
-        }
-    },
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
There is no `tests` folder, and the namespace was still using `ShuvroRoy` instead of the (I assume) intended `Reworck`.