### PR TITLE
Allow to configure a custom page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.0",
         "spatie/valuestore": "^1.2",
-        "livewire/livewire": "^v2.8.2"
+        "livewire/livewire": "^v3.0.0-beta.3"
     },
     "autoload": {
         "psr-4": {

--- a/config/filament-settings.php
+++ b/config/filament-settings.php
@@ -10,6 +10,9 @@ return [
     // Page title
     'title' => 'Settings',
 
+    // Replace with a custom page to have more control over appearance etc. 
+    'page' => \Reworck\FilamentSettings\Pages\Settings::class,
+
     // Path to the file to be used as storage
     'path' => storage_path('app/settings.json'),
 ];

--- a/src/FilamentSettingsProvider.php
+++ b/src/FilamentSettingsProvider.php
@@ -15,7 +15,7 @@ class FilamentSettingsProvider extends PluginServiceProvider
     protected function getPages(): array
     {
         return [
-            Settings::class,
+            config('filament-settings.page') ?? Settings::class,
         ];
     }
 }


### PR DESCRIPTION
This PR will allow configuring a custom page to gain more control over things like sort order, icons, access, etc.

The config shipped includes the packages page or if it's missing it falls back to the default page. 

This would also fix https://github.com/reworck/filament-settings/pull/5 and also allow to manually implement Filament Shield as requested in https://github.com/reworck/filament-settings/pull/8.